### PR TITLE
Fix yunohost version requirements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "email": "whypsi@riseup.net"
   },
   "requirements": {
-    "yunohost": ">> 3.8.1"
+    "yunohost": ">= 4.1.7.3"
   },
   "multi_instance": true,
   "services": [


### PR DESCRIPTION
    ! Using official helper ynh_legacy_permissions_delete_all implies requiring at least version 4.1, but manifest only requires 3.8.1 
    ! Using official helper ynh_legacy_permissions_exists implies requiring at least version 4.1, but manifest only requires 3.8.1
